### PR TITLE
handle "other" jellyfin libraries

### DIFF
--- a/ErsatzTV.Application/Jellyfin/Commands/SynchronizeJellyfinAdminUserIdHandler.cs
+++ b/ErsatzTV.Application/Jellyfin/Commands/SynchronizeJellyfinAdminUserIdHandler.cs
@@ -57,7 +57,7 @@ namespace ErsatzTV.Application.Jellyfin.Commands
             return await maybeUserId.Match(
                 userId =>
                 {
-                    _logger.LogDebug("Jellyfin admin user id is {UserId}", userId);
+                    // _logger.LogDebug("Jellyfin admin user id is {UserId}", userId);
                     _memoryCache.Set($"jellyfin_admin_user_id.{parameters.JellyfinMediaSource.Id}", userId);
                     return Task.FromResult<Either<BaseError, Unit>>(Unit.Default);
                 },

--- a/ErsatzTV.Infrastructure/Jellyfin/JellyfinApiClient.cs
+++ b/ErsatzTV.Infrastructure/Jellyfin/JellyfinApiClient.cs
@@ -196,7 +196,7 @@ namespace ErsatzTV.Infrastructure.Jellyfin
         }
 
         private static Option<JellyfinLibrary> Project(JellyfinLibraryResponse response) =>
-            response.CollectionType.ToLowerInvariant() switch
+            response.CollectionType?.ToLowerInvariant() switch
             {
                 "tvshows" => new JellyfinLibrary
                 {


### PR DESCRIPTION
Properly ignore "other" libraries. Fixes #191 