### PR TITLE
use ffmpeg 4.3 in docker

### DIFF
--- a/ErsatzTV.Core.Tests/FFmpeg/FFmpegPlaybackSettingsCalculatorTests.cs
+++ b/ErsatzTV.Core.Tests/FFmpeg/FFmpegPlaybackSettingsCalculatorTests.cs
@@ -107,7 +107,7 @@ namespace ErsatzTV.Core.Tests.FFmpeg
             }
 
             [Test]
-            public void ShouldNot_SetRealtime_ForHttpLiveStreaming()
+            public void Should_SetRealtime_ForHttpLiveStreaming()
             {
                 FFmpegProfile ffmpegProfile = TestProfile();
 
@@ -120,7 +120,7 @@ namespace ErsatzTV.Core.Tests.FFmpeg
                     DateTimeOffset.Now,
                     DateTimeOffset.Now);
 
-                actual.RealtimeOutput.Should().BeFalse();
+                actual.RealtimeOutput.Should().BeTrue();
             }
 
             [Test]

--- a/ErsatzTV.Core/FFmpeg/FFmpegComplexFilterBuilder.cs
+++ b/ErsatzTV.Core/FFmpeg/FFmpegComplexFilterBuilder.cs
@@ -18,18 +18,11 @@ namespace ErsatzTV.Core.FFmpeg
         private string _inputCodec;
         private bool _normalizeLoudness;
         private Option<IDisplaySize> _padToSize = None;
-        private bool _realtime;
         private Option<IDisplaySize> _scaleToSize = None;
 
         public FFmpegComplexFilterBuilder WithHardwareAcceleration(HardwareAccelerationKind hardwareAccelerationKind)
         {
             _hardwareAccelerationKind = Some(hardwareAccelerationKind);
-            return this;
-        }
-
-        public FFmpegComplexFilterBuilder WithRealtime(bool realtime)
-        {
-            _realtime = realtime;
             return this;
         }
 
@@ -101,11 +94,6 @@ namespace ErsatzTV.Core.FFmpeg
 
             _audioDuration.IfSome(
                 audioDuration => audioFilterQueue.Add($"apad=whole_dur={audioDuration.TotalMilliseconds}ms"));
-
-            if (_realtime)
-            {
-                videoFilterQueue.Add("realtime");
-            }
 
             bool usesHardwareFilters = acceleration != HardwareAccelerationKind.None && !isHardwareDecode &&
                                        (_deinterlace || _scaleToSize.IsSome);

--- a/ErsatzTV.Core/FFmpeg/FFmpegPlaybackSettings.cs
+++ b/ErsatzTV.Core/FFmpeg/FFmpegPlaybackSettings.cs
@@ -12,7 +12,7 @@ namespace ErsatzTV.Core.FFmpeg
         public List<string> FormatFlags { get; set; }
         public HardwareAccelerationKind HardwareAcceleration { get; set; }
         public string VideoDecoder { get; set; }
-        public bool RealtimeOutput { get; set; }
+        public bool RealtimeOutput => true;
         public Option<TimeSpan> StreamSeek { get; set; }
         public Option<IDisplaySize> ScaledSize { get; set; }
         public bool PadToDesiredResolution { get; set; }

--- a/ErsatzTV.Core/FFmpeg/FFmpegPlaybackSettingsCalculator.cs
+++ b/ErsatzTV.Core/FFmpeg/FFmpegPlaybackSettingsCalculator.cs
@@ -68,10 +68,8 @@ namespace ErsatzTV.Core.FFmpeg
                     result.AudioCodec = "copy";
                     result.VideoCodec = "copy";
                     result.Deinterlace = false;
-                    result.RealtimeOutput = false;
                     break;
                 case StreamingMode.TransportStream:
-                    result.RealtimeOutput = true;
                     result.HardwareAcceleration = ffmpegProfile.HardwareAcceleration;
 
                     if (NeedToScale(ffmpegProfile, version))

--- a/ErsatzTV.Core/FFmpeg/FFmpegProcessBuilder.cs
+++ b/ErsatzTV.Core/FFmpeg/FFmpegProcessBuilder.cs
@@ -90,7 +90,11 @@ namespace ErsatzTV.Core.FFmpeg
 
         public FFmpegProcessBuilder WithRealtimeOutput(bool realtimeOutput)
         {
-            _complexFilterBuilder = _complexFilterBuilder.WithRealtime(realtimeOutput);
+            if (realtimeOutput)
+            {
+                _arguments.Add("-re");
+            }
+
             return this;
         }
 
@@ -389,7 +393,7 @@ namespace ErsatzTV.Core.FFmpeg
             {
                 FileName = _ffmpegPath,
                 RedirectStandardOutput = true,
-                RedirectStandardError = true,
+                RedirectStandardError = false,
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 StandardOutputEncoding = Encoding.UTF8

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:5.0-focal-amd64 AS dotnet-runtime
 
-FROM jrottenberg/ffmpeg:4.4-ubuntu2004 AS runtime-base
+FROM jrottenberg/ffmpeg:4.3-ubuntu2004 AS runtime-base
 COPY --from=dotnet-runtime /usr/share/dotnet /usr/share/dotnet
 RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y libicu-dev tzdata
 

--- a/docker/nvidia/Dockerfile
+++ b/docker/nvidia/Dockerfile
@@ -1,6 +1,6 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:5.0-focal-amd64 AS dotnet-runtime
 
-FROM jrottenberg/ffmpeg:4.4-nvidia1804 AS runtime-base
+FROM jrottenberg/ffmpeg:4.3-nvidia1804 AS runtime-base
 COPY --from=dotnet-runtime /usr/share/dotnet /usr/share/dotnet
 RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y libicu-dev tzdata
 

--- a/docker/vaapi/Dockerfile
+++ b/docker/vaapi/Dockerfile
@@ -1,6 +1,6 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:5.0-focal-amd64 AS dotnet-runtime
 
-FROM jrottenberg/ffmpeg:4.4-vaapi2004 AS runtime-base
+FROM jrottenberg/ffmpeg:4.3-vaapi2004 AS runtime-base
 COPY --from=dotnet-runtime /usr/share/dotnet /usr/share/dotnet
 RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y libicu-dev tzdata
 


### PR DESCRIPTION
The ffmpeg 4.4 build in the jrottenberg/ffmpeg docker images does not behave properly when `-re` and `-ss` are used together. Until that is resolved, we need to stick with ffmpeg 4.3 in docker because the performance of `-re` is significantly better than the `realtime` filter.

This effectively reverts #182 