### PR TITLE
Add ESLint and Prettier for VueJS

### DIFF
--- a/.github/workflows/vue-lint.yml
+++ b/.github/workflows/vue-lint.yml
@@ -20,4 +20,3 @@ jobs:
           npm ci --no-optional
           npm run lint
           npm run build --if-present
-          

--- a/.github/workflows/vue-lint.yml
+++ b/.github/workflows/vue-lint.yml
@@ -1,0 +1,23 @@
+﻿name: Lint VueJS Files on PR Request
+on:
+  pull_request:
+jobs:
+  vue-lint:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the current repo
+      - name: Checkout current repository
+        uses: actions/checkout@v2
+      # Setup NodeJS version 14  
+      - name: Setup NodeJS V14.x.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      # CD into the current client directory and lint and build the client
+      - name: Lint and Build the client  
+        run: |
+          cd ./ErsatzTV/client-app/
+          npm ci --no-optional
+          npm run lint
+          npm run build --if-present
+          

--- a/ErsatzTV/client-app/README.md
+++ b/ErsatzTV/client-app/README.md
@@ -22,3 +22,4 @@ npm run lint
 
 ### Customize configuration
 See [Configuration Reference](https://cli.vuejs.org/config/).
+

--- a/ErsatzTV/client-app/babel.config.js
+++ b/ErsatzTV/client-app/babel.config.js
@@ -1,5 +1,3 @@
 module.exports = {
-  presets: [
-    '@vue/cli-plugin-babel/preset'
-  ]
-}
+    presets: ["@vue/cli-plugin-babel/preset"],
+};

--- a/ErsatzTV/client-app/package-lock.json
+++ b/ErsatzTV/client-app/package-lock.json
@@ -24,6 +24,8 @@
         "@vue/cli-service": "~5.0.0",
         "@vue/composition-api": "^1.4.9",
         "eslint": "^7.32.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-vue": "^8.0.3",
         "sass": "~1.32.0",
         "sass-loader": "^10.0.0",
@@ -5024,6 +5026,39 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
+      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.28.0",
+        "prettier": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-plugin-vue": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-8.5.0.tgz",
@@ -5620,6 +5655,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "node_modules/fast-glob": {
@@ -8907,12 +8948,23 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
       "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true,
-      "optional": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-error": {
@@ -15549,6 +15601,22 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-plugin-prettier": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
+      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "eslint-plugin-vue": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-8.5.0.tgz",
@@ -15878,6 +15946,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-glob": {
@@ -18274,8 +18348,16 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
       "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
       "dev": true,
-      "optional": true
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-error": {
       "version": "4.0.0",

--- a/ErsatzTV/client-app/package.json
+++ b/ErsatzTV/client-app/package.json
@@ -24,6 +24,8 @@
     "@vue/cli-service": "~5.0.0",
     "@vue/composition-api": "^1.4.9",
     "eslint": "^7.32.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-vue": "^8.0.3",
     "sass": "~1.32.0",
     "sass-loader": "^10.0.0",
@@ -38,6 +40,7 @@
     },
     "extends": [
       "plugin:vue/essential",
+      "plugin:prettier/recommended",
       "eslint:recommended"
     ],
     "parserOptions": {

--- a/ErsatzTV/client-app/src/App.vue
+++ b/ErsatzTV/client-app/src/App.vue
@@ -8,7 +8,7 @@
                 <!-- If using vue-router -->
                 <router-view></router-view>
             </v-container>
-            <SnackBar/>
+            <SnackBar />
         </v-main>
     </v-app>
 </template>
@@ -20,7 +20,7 @@ import SnackBar from "@/components/PopUps/SnackBar";
 export default Vue.extend({
     name: "App",
     components: { Toolbar, SnackBar },
-    data: () => ({})
+    data: () => ({}),
 });
 </script>
 <style>

--- a/ErsatzTV/client-app/src/components/Navigation/SideBarLogo.vue
+++ b/ErsatzTV/client-app/src/components/Navigation/SideBarLogo.vue
@@ -1,20 +1,27 @@
 ﻿<template>
     <span>
-        <v-img v-if="!isNavigationMini" src="@/assets/images/ersatztv.png" class="ma-3"></v-img>
-        <v-img v-if="isNavigationMini" src="@/assets/images/ersatztv-500.png" class="ma-1"></v-img>
-        <hr>
+        <v-img
+            v-if="!isNavigationMini"
+            src="@/assets/images/ersatztv.png"
+            class="ma-3"
+        ></v-img>
+        <v-img
+            v-if="isNavigationMini"
+            src="@/assets/images/ersatztv-500.png"
+            class="ma-1"
+        ></v-img>
+        <hr />
     </span>
-
 </template>
 
 <script>
-import { mapState } from 'pinia'
-import { applicationState } from '@/stores/applicationState'
+import { mapState } from "pinia";
+import { applicationState } from "@/stores/applicationState";
 
 export default {
     name: "SideBarLogo",
     computed: {
-        ...mapState(applicationState, ['isNavigationMini'])
+        ...mapState(applicationState, ["isNavigationMini"]),
     },
-}
+};
 </script>

--- a/ErsatzTV/client-app/src/components/Navigation/SideBarLogo.vue
+++ b/ErsatzTV/client-app/src/components/Navigation/SideBarLogo.vue
@@ -10,7 +10,7 @@
             src="@/assets/images/ersatztv-500.png"
             class="ma-1"
         ></v-img>
-        <hr />
+        <v-divider inset></v-divider>
     </span>
 </template>
 

--- a/ErsatzTV/client-app/src/components/Navigation/SideBarMenu.vue
+++ b/ErsatzTV/client-app/src/components/Navigation/SideBarMenu.vue
@@ -1,36 +1,30 @@
 ﻿<template>
-    <v-list
-        nav
-        dense
-    >
-    <span
-        v-for="(nav, i) in navigation"
-        :key="i"
-    >
-        <SideBarMenuItem
-            v-if="!nav.children"
-            :name="nav.name" 
-            :path="nav.path" 
-            :icon="nav.meta.icon" 
-            :disabled="nav.meta.disabled"
-        /> 
-        <SideBarMenuItemExpandable
-            v-else
-            @click.native="disableMiniNavigation()"
-            :name="nav.name"
-            :icon="nav.meta.icon"
-            :disabled="nav.meta.disabled"
-            :children="nav.children"
-        /> 
-    </span>
+    <v-list nav dense>
+        <span v-for="(nav, i) in navigation" :key="i">
+            <SideBarMenuItem
+                v-if="!nav.children"
+                :name="nav.name"
+                :path="nav.path"
+                :icon="nav.meta.icon"
+                :disabled="nav.meta.disabled"
+            />
+            <SideBarMenuItemExpandable
+                v-else
+                @click.native="disableMiniNavigation()"
+                :name="nav.name"
+                :icon="nav.meta.icon"
+                :disabled="nav.meta.disabled"
+                :children="nav.children"
+            />
+        </span>
     </v-list>
 </template>
 
 <script>
-import SideBarMenuItem from "./SideBarMenuItem"
-import SideBarMenuItemExpandable from "./SideBarMenuItemExpandable"
-import { mapState } from 'pinia';
-import { applicationState } from '@/stores/applicationState';
+import SideBarMenuItem from "./SideBarMenuItem";
+import SideBarMenuItemExpandable from "./SideBarMenuItemExpandable";
+import { mapState } from "pinia";
+import { applicationState } from "@/stores/applicationState";
 
 export default {
     name: "NavSidebar",
@@ -39,11 +33,11 @@ export default {
         navigation: null,
     }),
     computed: {
-        ...mapState(applicationState, ['disableMiniNavigation'])
+        ...mapState(applicationState, ["disableMiniNavigation"]),
     },
-    beforeMount: function() {
+    beforeMount: function () {
         //Pull in navigation from routes and load into DOM
         this.navigation = this.$router.options.routes;
-    }
+    },
 };
 </script>

--- a/ErsatzTV/client-app/src/components/Navigation/SideBarMenuItem.vue
+++ b/ErsatzTV/client-app/src/components/Navigation/SideBarMenuItem.vue
@@ -1,14 +1,8 @@
 ﻿<template>
     <v-list-item-group color="primary">
-        <v-list-item
-            :to="path"
-            :disabled="disabled"
-        >
+        <v-list-item :to="path" :disabled="disabled">
             <v-list-item-icon>
-                <v-icon
-                    v-text="icon"
-                    :disabled="disabled"
-                />
+                <v-icon v-text="icon" :disabled="disabled" />
             </v-list-item-icon>
 
             <v-list-item-content>
@@ -23,21 +17,21 @@ export default {
     name: "SideBarMenuItem",
     props: {
         name: {
-          type: String,
-          required: true  
+            type: String,
+            required: true,
         },
         path: {
             type: String,
-            required: true
+            required: true,
         },
         icon: {
             type: String,
-            required: true
+            required: true,
         },
         disabled: {
             type: Boolean,
-            required: true
-        }
-    }
-}
+            required: true,
+        },
+    },
+};
 </script>

--- a/ErsatzTV/client-app/src/components/Navigation/SideBarMenuItemExpandable.vue
+++ b/ErsatzTV/client-app/src/components/Navigation/SideBarMenuItemExpandable.vue
@@ -1,18 +1,17 @@
 ﻿<template>
-    <v-list-group 
+    <v-list-group
         color="primary"
         v-model="menuItemOpened"
         :disabled="disabled"
         :prepend-icon="icon"
         no-action
     >
-        
         <template v-slot:activator>
             <v-list-item-content>
                 <v-list-item-title v-text="name"></v-list-item-title>
             </v-list-item-content>
         </template>
-        
+
         <v-list-item
             v-for="child in children"
             :key="child.name"
@@ -29,7 +28,6 @@
                 <v-list-item-title v-text="child.name"></v-list-item-title>
             </v-list-item-content>
         </v-list-item>
-        
     </v-list-group>
 </template>
 
@@ -38,34 +36,34 @@ export default {
     name: "SideBarMenuItemExpandable",
     props: {
         name: {
-          type: String,
-          required: true  
+            type: String,
+            required: true,
         },
         icon: {
             type: String,
-            required: true
+            required: true,
         },
         disabled: {
             type: Boolean,
-            required: true
+            required: true,
         },
         children: {
             type: Array,
-            required: true
-        }
+            required: true,
+        },
     },
     data: () => ({
         opened: false,
     }),
     computed: {
         menuItemOpened: {
-            get: function() {
-                return this.opened
+            get: function () {
+                return this.opened;
             },
-            set: function() {
-                return !this.opened
-            }
-        }
-    }
-}
+            set: function () {
+                return !this.opened;
+            },
+        },
+    },
+};
 </script>

--- a/ErsatzTV/client-app/src/components/Navigation/SideBarVersion.vue
+++ b/ErsatzTV/client-app/src/components/Navigation/SideBarVersion.vue
@@ -1,6 +1,6 @@
 ﻿<template>
     <span v-if="!isNavigationMini" class="text-center">
-        <hr />
+        <v-divider inset></v-divider>
         <h4 class="pt-2">ErsatzTV Version</h4>
 
         <p>{{ currentServerVersion }}</p>

--- a/ErsatzTV/client-app/src/components/Navigation/SideBarVersion.vue
+++ b/ErsatzTV/client-app/src/components/Navigation/SideBarVersion.vue
@@ -1,9 +1,6 @@
 ﻿<template>
-    <span 
-        v-if="!isNavigationMini"
-        class="text-center"
-    >
-        <hr>
+    <span v-if="!isNavigationMini" class="text-center">
+        <hr />
         <h4 class="pt-2">ErsatzTV Version</h4>
 
         <p>{{ currentServerVersion }}</p>
@@ -11,17 +8,18 @@
 </template>
 
 <script>
-import { mapState } from 'pinia'
-import { applicationState } from '@/stores/applicationState'
+import { mapState } from "pinia";
+import { applicationState } from "@/stores/applicationState";
 
 export default {
-  name: "SideBarVersion",
-computed: {
-    ...mapState(applicationState, ['currentServerVersion', 'isNavigationMini'])
-}
-}
+    name: "SideBarVersion",
+    computed: {
+        ...mapState(applicationState, [
+            "currentServerVersion",
+            "isNavigationMini",
+        ]),
+    },
+};
 </script>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/ErsatzTV/client-app/src/components/Navigation/ToolBar.vue
+++ b/ErsatzTV/client-app/src/components/Navigation/ToolBar.vue
@@ -1,27 +1,18 @@
 ﻿<template>
     <nav>
-        <v-app-bar
-            flat
-            app
-            dense
-            absolute
-        >
+        <v-app-bar flat app dense absolute>
             <v-app-bar-nav-icon @click.stop="toggleMiniNavigation()" />
-            
+
             <ToolBarSearch />
             <v-spacer />
 
             <ToolBarLinks />
         </v-app-bar>
-        <v-navigation-drawer
-            app
-            :mini-variant="isNavigationMini"
-            permanent
-        >
+        <v-navigation-drawer app :mini-variant="isNavigationMini" permanent>
             <template v-slot:prepend>
                 <SideBarLogo />
             </template>
-  
+
             <SideBarMenu />
             <template v-slot:append>
                 <SideBarVersion />
@@ -36,14 +27,23 @@ import SideBarMenu from "./SideBarMenu.vue";
 import SideBarVersion from "./SideBarVersion";
 import ToolBarLinks from "./ToolBarLinks";
 import ToolBarSearch from "./ToolBarSearch";
-import { mapState } from 'pinia';
-import { applicationState } from '@/stores/applicationState';
+import { mapState } from "pinia";
+import { applicationState } from "@/stores/applicationState";
 
 export default {
     name: "NavToolbar",
-    components: { SideBarMenu, SideBarLogo, SideBarVersion, ToolBarLinks, ToolBarSearch },
+    components: {
+        SideBarMenu,
+        SideBarLogo,
+        SideBarVersion,
+        ToolBarLinks,
+        ToolBarSearch,
+    },
     computed: {
-        ...mapState(applicationState, ['isNavigationMini', 'toggleMiniNavigation'])
-    }
+        ...mapState(applicationState, [
+            "isNavigationMini",
+            "toggleMiniNavigation",
+        ]),
+    },
 };
 </script>

--- a/ErsatzTV/client-app/src/components/Navigation/ToolBarLinks.vue
+++ b/ErsatzTV/client-app/src/components/Navigation/ToolBarLinks.vue
@@ -1,100 +1,97 @@
 ﻿<template>
     <span>
         <v-tooltip bottom>
-          <template v-slot:activator="{ on, attrs }">
-            <v-btn
-                class="ma-2"
-                outlined
-                color="primary"
-                @click="copyTextToClipboard(navBarURLs.m3uURL)"
-                v-bind="attrs"
-                v-on="on"
-                small
-            >
-              <v-icon>mdi-playlist-play</v-icon>   M3U
-            </v-btn>
-          </template>
-          <span>{{ clickToCopyText }}</span>
+            <template v-slot:activator="{ on, attrs }">
+                <v-btn
+                    class="ma-2"
+                    outlined
+                    color="primary"
+                    @click="copyTextToClipboard(navBarURLs.m3uURL)"
+                    v-bind="attrs"
+                    v-on="on"
+                    small
+                >
+                    <v-icon>mdi-playlist-play</v-icon> M3U
+                </v-btn>
+            </template>
+            <span>{{ clickToCopyText }}</span>
         </v-tooltip>
-        
+
         <v-tooltip bottom>
-          <template v-slot:activator="{ on, attrs }">
-            <v-btn
-                class="ma-2"
-                outlined
-                color="primary"
-                @click="copyTextToClipboard(navBarURLs.xmlURL)"
-                v-bind="attrs"
-                v-on="on"
-                small
-            >
-            <v-icon>mdi-xml</v-icon> XML
-            </v-btn>
-        </template>
-        <span>{{ clickToCopyText }}</span>
+            <template v-slot:activator="{ on, attrs }">
+                <v-btn
+                    class="ma-2"
+                    outlined
+                    color="primary"
+                    @click="copyTextToClipboard(navBarURLs.xmlURL)"
+                    v-bind="attrs"
+                    v-on="on"
+                    small
+                >
+                    <v-icon>mdi-xml</v-icon> XML
+                </v-btn>
+            </template>
+            <span>{{ clickToCopyText }}</span>
         </v-tooltip>
-        
+
         <v-btn
             icon
             color="secondary"
-            :href="navBarURLs.documentationURL" 
+            :href="navBarURLs.documentationURL"
             target="_blank"
         >
-           <v-icon>mdi-file-document</v-icon>
+            <v-icon>mdi-file-document</v-icon>
         </v-btn>
-        
+
         <v-btn
             icon
             color="secondary"
-            :href="navBarURLs.discordURL" 
+            :href="navBarURLs.discordURL"
             target="_blank"
         >
-           <v-icon>mdi-discord</v-icon>
+            <v-icon>mdi-discord</v-icon>
         </v-btn>
-        
+
         <v-btn
             icon
             color="secondary"
-            :href="navBarURLs.githubURL" 
+            :href="navBarURLs.githubURL"
             target="_blank"
         >
-           <v-icon>mdi-github</v-icon>
+            <v-icon>mdi-github</v-icon>
         </v-btn>
     </span>
 </template>
 
 <script>
-import { mapState } from 'pinia';
-import { applicationState } from '@/stores/applicationState';
+import { mapState } from "pinia";
+import { applicationState } from "@/stores/applicationState";
 import { snackbarState } from "@/stores/snackbarState";
 
 export default {
-  name: "ToolBarLinks.vue", 
-  data: () => ({
-      toast: false,
-      clickToCopyText: "Click to copy to clipboard!",
-      successCopyText: "Successfully copied text to clipboard!",
-      failedCopyText: "Failed to copy text to clipboard! Error: "
-  }),
-  computed: {
-      ...mapState(applicationState, ['navBarURLs']),
-      ...mapState(snackbarState, ['showSnackbar'])
-  },
-  methods: {
-      copyTextToClipboard(text) {
-          try{
-            navigator.clipboard.writeText(text);
-            this.showSnackbar(this.successCopyText)
-          }catch(e){
-              console.error(e)
-              this.showSnackbar(`${this.failedCopyText}${e}`)
-          }
-
-      }
-  }  
-}
+    name: "ToolBarLinks.vue",
+    data: () => ({
+        toast: false,
+        clickToCopyText: "Click to copy to clipboard!",
+        successCopyText: "Successfully copied text to clipboard!",
+        failedCopyText: "Failed to copy text to clipboard! Error: ",
+    }),
+    computed: {
+        ...mapState(applicationState, ["navBarURLs"]),
+        ...mapState(snackbarState, ["showSnackbar"]),
+    },
+    methods: {
+        copyTextToClipboard(text) {
+            try {
+                navigator.clipboard.writeText(text);
+                this.showSnackbar(this.successCopyText);
+            } catch (e) {
+                console.error(e);
+                this.showSnackbar(`${this.failedCopyText}${e}`);
+            }
+        },
+    },
+};
 </script>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/ErsatzTV/client-app/src/components/Navigation/ToolBarSearch.vue
+++ b/ErsatzTV/client-app/src/components/Navigation/ToolBarSearch.vue
@@ -11,10 +11,8 @@
 
 <script>
 export default {
-  name: "ToolBarSearch"
-}
+    name: "ToolBarSearch",
+};
 </script>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/ErsatzTV/client-app/src/components/PopUps/SnackBar.vue
+++ b/ErsatzTV/client-app/src/components/PopUps/SnackBar.vue
@@ -1,31 +1,35 @@
 ﻿<template>
-    <v-snackbar 
-        v-model="snackbar"
-        :timeout="timeout"
-    >
-        {{currentMessage}}
-        <v-btn text color="primary" @click.native="closeSnackbar()">Close</v-btn>
+    <v-snackbar v-model="snackbar" :timeout="timeout">
+        {{ currentMessage }}
+        <v-btn text color="primary" @click.native="closeSnackbar()"
+            >Close</v-btn
+        >
     </v-snackbar>
 </template>
 
 <script>
-import { mapState } from 'pinia';
-import { snackbarState } from '@/stores/snackbarState';
+import { mapState } from "pinia";
+import { snackbarState } from "@/stores/snackbarState";
 
 export default {
     data: () => ({
         timeout: 4000,
     }),
     computed: {
-        ...mapState(snackbarState, ['currentMessage', 'isVisible', 'closeSnackbar', 'openSnackbar']),
+        ...mapState(snackbarState, [
+            "currentMessage",
+            "isVisible",
+            "closeSnackbar",
+            "openSnackbar",
+        ]),
         snackbar: {
             get() {
-                return this.isVisible
+                return this.isVisible;
             },
             set() {
                 this.closeSnackbar();
-            }
-        }
+            },
+        },
     },
-}
+};
 </script>

--- a/ErsatzTV/client-app/src/main.js
+++ b/ErsatzTV/client-app/src/main.js
@@ -1,22 +1,23 @@
-import Vue from 'vue'
-import App from './App.vue'
-import vuetify from './plugins/vuetify'
-import router from './router'
-import { createPinia, PiniaVuePlugin } from 'pinia'
-import autoPageTitleMixin from './mixins/autoPageTitle'
-import 'roboto-fontface/css/roboto/roboto-fontface.css'
-import '@mdi/font/css/materialdesignicons.css'
+import Vue from "vue";
+import App from "./App.vue";
+import vuetify from "./plugins/vuetify";
+import router from "./router";
+import { createPinia, PiniaVuePlugin } from "pinia";
+import autoPageTitleMixin from "./mixins/autoPageTitle";
+import "roboto-fontface/css/roboto/roboto-fontface.css";
+import "@mdi/font/css/materialdesignicons.css";
 
-Vue.config.productionTip = false
+Vue.config.productionTip = false;
 
-
-Vue.use(PiniaVuePlugin)
-const pinia = createPinia()
+Vue.use(PiniaVuePlugin);
+const pinia = createPinia();
 
 // Mixin to automate the page title when navigating... Will default to "ErsatzTV if no title value exported from page.
-Vue.mixin(autoPageTitleMixin)
+Vue.mixin(autoPageTitleMixin);
 
 new Vue({
-  vuetify, router, pinia,
-  render: h => h(App)
-}).$mount('#app')
+    vuetify,
+    router,
+    pinia,
+    render: (h) => h(App),
+}).$mount("#app");

--- a/ErsatzTV/client-app/src/mixins/autoPageTitle.js
+++ b/ErsatzTV/client-app/src/mixins/autoPageTitle.js
@@ -1,17 +1,15 @@
-﻿function getTitle (vm) {
-    const { title } = vm.$options
+﻿function getTitle(vm) {
+    const { title } = vm.$options;
     if (title) {
-        return typeof title === 'function'
-            ? title.call(vm)
-            : title
+        return typeof title === "function" ? title.call(vm) : title;
     }
 }
 
 export default {
-    created () {
-        const title = getTitle(this)
+    created() {
+        const title = getTitle(this);
         if (title) {
-            document.title = `ErsatzTV | ${title}`
+            document.title = `ErsatzTV | ${title}`;
         }
-    }
-}
+    },
+};

--- a/ErsatzTV/client-app/src/plugins/vuetify.js
+++ b/ErsatzTV/client-app/src/plugins/vuetify.js
@@ -1,28 +1,28 @@
-import Vue from 'vue';
-import Vuetify from 'vuetify/lib/framework';
-import colors from 'vuetify/lib/util/colors'
+import Vue from "vue";
+import Vuetify from "vuetify/lib/framework";
+import colors from "vuetify/lib/util/colors";
 
 Vue.use(Vuetify);
 
 export default new Vuetify({
-  icons: {
-      iconfont: "mdi", // default - only for display purposes
-  },
-  theme: {
-      themes: {
-          dark: {
-              primary: colors.yellow,
-              secondary: colors.teal.accent3,
-              accent: colors.yellow.accent2,
-              error: colors.red,
-              warning: colors.orange,
-              info: colors.lightBlue,
-              success: colors.green,
-          },
-      },
-      options: {
-          customProperties: true,
-      },
-      dark: true,
-  },
+    icons: {
+        iconfont: "mdi", // default - only for display purposes
+    },
+    theme: {
+        themes: {
+            dark: {
+                primary: colors.yellow,
+                secondary: colors.teal.accent3,
+                accent: colors.yellow.accent2,
+                error: colors.red,
+                warning: colors.orange,
+                info: colors.lightBlue,
+                success: colors.green,
+            },
+        },
+        options: {
+            customProperties: true,
+        },
+        dark: true,
+    },
 });

--- a/ErsatzTV/client-app/src/router/index.js
+++ b/ErsatzTV/client-app/src/router/index.js
@@ -11,32 +11,32 @@ const routes = [
         component: HomePage,
         meta: {
             icon: "mdi-home",
-            disabled: false
-        }
+            disabled: false,
+        },
     },
     {
         path: "/channels",
         name: "Channels",
         meta: {
             icon: "mdi-broadcast",
-            disabled: true
-        }
+            disabled: true,
+        },
     },
     {
         path: "/ffmpeg-profiles",
         name: "FFmpeg Profiles",
         meta: {
             icon: "mdi-video-input-component",
-            disabled: true
-        }
+            disabled: true,
+        },
     },
     {
         path: "/watermarks",
         name: "Watermarks",
         meta: {
             icon: "mdi-watermark",
-            disabled: true
-        }
+            disabled: true,
+        },
     },
     {
         path: "/sources",
@@ -51,34 +51,34 @@ const routes = [
                 name: "Local",
                 meta: {
                     icon: "mdi-folder",
-                    disabled: true
-                }
+                    disabled: true,
+                },
             },
             {
                 path: "/sources/emby",
                 name: "Emby",
                 meta: {
                     icon: "mdi-emby",
-                    disabled: true
-                }
+                    disabled: true,
+                },
             },
             {
                 path: "/sources/jellyfin",
                 name: "Jellyfin",
                 meta: {
                     icon: "mdi-jellyfish",
-                    disabled: true
-                }
+                    disabled: true,
+                },
             },
             {
                 path: "/sources/plex",
                 name: "Plex",
                 meta: {
                     icon: "mdi-plex",
-                    disabled: true
-                }
+                    disabled: true,
+                },
             },
-        ]
+        ],
     },
     {
         path: "/media",
@@ -93,58 +93,58 @@ const routes = [
                 name: "Libraries",
                 meta: {
                     icon: "mdi-library",
-                    disabled: true
-                }
+                    disabled: true,
+                },
             },
             {
                 path: "/media/trash",
                 name: "Trash",
                 meta: {
                     icon: "mdi-trash-can",
-                    disabled: true
-                }
+                    disabled: true,
+                },
             },
             {
                 path: "/media/tv-shows",
                 name: "TV Shows",
                 meta: {
                     icon: "mdi-television-classic",
-                    disabled: true
-                }
+                    disabled: true,
+                },
             },
             {
                 path: "/media/movies",
                 name: "Movies",
                 meta: {
                     icon: "mdi-movie",
-                    disabled: true
-                }
+                    disabled: true,
+                },
             },
             {
                 path: "/media/music-videos",
                 name: "Music Videos",
                 meta: {
                     icon: "mdi-music-circle",
-                    disabled: true
-                }
+                    disabled: true,
+                },
             },
             {
                 path: "/media/other-videos",
                 name: "Other Videos",
                 meta: {
                     icon: "mdi-video",
-                    disabled: true
-                }
+                    disabled: true,
+                },
             },
             {
                 path: "/media/songs",
                 name: "Songs",
                 meta: {
                     icon: "mdi-album",
-                    disabled: true
-                }
+                    disabled: true,
+                },
             },
-        ]
+        ],
     },
     {
         path: "/lists",
@@ -159,57 +159,57 @@ const routes = [
                 name: "Collections",
                 meta: {
                     icon: "mdi-collage",
-                    disabled: true
-                }
+                    disabled: true,
+                },
             },
             {
                 path: "/lists/trakt-lists",
                 name: "Trakt Lists",
                 meta: {
                     icon: "mdi-hammer",
-                    disabled: true
-                }
+                    disabled: true,
+                },
             },
             {
                 path: "/lists/filler-presets",
                 name: "Filler Presets",
                 meta: {
                     icon: "mdi-tune-vertical",
-                    disabled: true
-                }
+                    disabled: true,
+                },
             },
-        ]
+        ],
     },
     {
         path: "/schedules",
         name: "Schedules",
         meta: {
             icon: "mdi-calendar",
-            disabled: true
-        }
+            disabled: true,
+        },
     },
     {
         path: "/playouts",
         name: "Playouts",
         meta: {
             icon: "mdi-clipboard-play-multiple",
-            disabled: true
-        }
+            disabled: true,
+        },
     },
     {
         path: "/settings",
         name: "Settings",
         meta: {
             icon: "mdi-cog",
-            disabled: true
-        }
+            disabled: true,
+        },
     },
     {
         path: "/Logs",
         name: "Logs",
         meta: {
             icon: "mdi-card-text",
-            disabled: true
+            disabled: true,
         },
     },
 ];

--- a/ErsatzTV/client-app/src/stores/applicationState.js
+++ b/ErsatzTV/client-app/src/stores/applicationState.js
@@ -1,8 +1,8 @@
-﻿import { defineStore } from 'pinia'
+﻿import { defineStore } from "pinia";
 
-const pageURL = `${window.location}`
+const pageURL = `${window.location}`;
 
-export const applicationState = defineStore('appState', {
+export const applicationState = defineStore("appState", {
     state: () => {
         return {
             miniMenu: false,
@@ -11,32 +11,32 @@ export const applicationState = defineStore('appState', {
             xmlURL: pageURL + "iptv/xmltv.xml",
             documentationURL: "https://ersatztv.org/",
             githubURL: "https://github.com/jasongdove/ErsatzTV",
-            discordURL: "https://discord.gg/hHaJm3yGy6"
-        }
+            discordURL: "https://discord.gg/hHaJm3yGy6",
+        };
     },
     getters: {
         isNavigationMini(state) {
-            return state.miniMenu
+            return state.miniMenu;
         },
-        currentServerVersion(state){
-            return state.currentVersion
+        currentServerVersion(state) {
+            return state.currentVersion;
         },
-        navBarURLs(state){
+        navBarURLs(state) {
             return {
                 m3uURL: state.m3uURL,
                 xmlURL: state.xmlURL,
                 documentationURL: state.documentationURL,
                 githubURL: state.githubURL,
-                discordURL: state.discordURL
-            }
-        }
+                discordURL: state.discordURL,
+            };
+        },
     },
     actions: {
         toggleMiniNavigation() {
-            this.miniMenu = !this.miniMenu
+            this.miniMenu = !this.miniMenu;
         },
         disableMiniNavigation() {
-            this.miniMenu = false
+            this.miniMenu = false;
         },
     },
-})
+});

--- a/ErsatzTV/client-app/src/stores/snackbarState.js
+++ b/ErsatzTV/client-app/src/stores/snackbarState.js
@@ -1,27 +1,27 @@
-﻿import { defineStore } from 'pinia'
+﻿import { defineStore } from "pinia";
 
-export const snackbarState = defineStore('snackbarState', {
+export const snackbarState = defineStore("snackbarState", {
     state: () => {
         return {
             visible: false,
-            message: ""
-        }
+            message: "",
+        };
     },
     getters: {
         isVisible(state) {
-            return state.visible
+            return state.visible;
         },
-        currentMessage(state){
-            return state.message
-        }
+        currentMessage(state) {
+            return state.message;
+        },
     },
     actions: {
         showSnackbar(message) {
-            this.message = message
-            this.visible = true
+            this.message = message;
+            this.visible = true;
         },
         closeSnackbar() {
             this.visible = false;
         },
     },
-})
+});

--- a/ErsatzTV/client-app/src/views/HomePage.vue
+++ b/ErsatzTV/client-app/src/views/HomePage.vue
@@ -6,8 +6,8 @@
 
 <script>
 export default {
-    title () {
-        return `Home`
-    }
+    title() {
+        return `Home`;
+    },
 };
 </script>

--- a/ErsatzTV/client-app/vue.config.js
+++ b/ErsatzTV/client-app/vue.config.js
@@ -1,12 +1,10 @@
-const { defineConfig } = require('@vue/cli-service')
+const { defineConfig } = require("@vue/cli-service");
 
 module.exports = defineConfig({
-  transpileDependencies: [
-    'vuetify'
-  ],
-  runtimeCompiler: true,
+    transpileDependencies: ["vuetify"],
+    runtimeCompiler: true,
 
-  pwa: {
-      name: "ErsatzTV",
-  },
-})
+    pwa: {
+        name: "ErsatzTV",
+    },
+});


### PR DESCRIPTION
This PR adds the required packages and config for ESLint and Prettier. 

They are both run over the client-app project with `npm run lint` 

I've also added a github action to run this on PR submittal. Currently it doesn't re-commit the linted files and will just output any failures. Depends how fancy you want to get really! 

- [x] Add eslint and prettier plugins for vueJS. 
- [x] Update package.json to enable the use of prettier plugin. 
- [x] Run `npm run lint` over files to clean up and standardise previous commit. 
- [x] Add's github action to check files are linted on PR and a build is successful