### PR TITLE
force prettier indenting and end of line

### DIFF
--- a/ErsatzTV/client-app/package.json
+++ b/ErsatzTV/client-app/package.json
@@ -46,7 +46,14 @@
     "parserOptions": {
       "parser": "@babel/eslint-parser"
     },
-    "rules": {}
+    "rules": {
+      "prettier/prettier": [
+        "error", {
+          "endOfLine": "auto",
+          "tabWidth": 4
+        }
+      ]
+    }
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
Fixes the build process in docker by forcing the ESlint/Prettier config in package.json