### PR TITLE
fix qsv audio sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix HDR transcoding with NVIDIA accel for:
     - All NVIDIA docker users
     - Windows NVIDIA users who have set the `ETV_DISABLE_VULKAN` env var
+- Fix audio sync issue with QSV acceleration
 
 ## [25.2.0] - 2025-06-24
 ### Added

--- a/ErsatzTV.FFmpeg/Capabilities/HardwareCapabilitiesFactory.cs
+++ b/ErsatzTV.FFmpeg/Capabilities/HardwareCapabilitiesFactory.cs
@@ -135,7 +135,7 @@ public class HardwareCapabilitiesFactory : IHardwareCapabilitiesFactory
 
     public async Task<QsvOutput> GetQsvOutput(string ffmpegPath, Option<string> qsvDevice)
     {
-        var option = new QsvHardwareAccelerationOption(qsvDevice);
+        var option = new QsvHardwareAccelerationOption(qsvDevice, FFmpegCapability.Software);
         var arguments = option.GlobalOptions.ToList();
 
         arguments.AddRange(QsvArguments);

--- a/ErsatzTV.FFmpeg/GlobalOption/HardwareAcceleration/QsvHardwareAccelerationOption.cs
+++ b/ErsatzTV.FFmpeg/GlobalOption/HardwareAcceleration/QsvHardwareAccelerationOption.cs
@@ -1,19 +1,16 @@
-﻿using ErsatzTV.FFmpeg.Format;
+﻿using ErsatzTV.FFmpeg.Capabilities;
+using ErsatzTV.FFmpeg.Format;
 
 namespace ErsatzTV.FFmpeg.GlobalOption.HardwareAcceleration;
 
-public class QsvHardwareAccelerationOption : GlobalOption
+public class QsvHardwareAccelerationOption(Option<string> device, FFmpegCapability decodeCapability) : GlobalOption
 {
-    private readonly Option<string> _qsvDevice;
-
     // TODO: read this from ffmpeg output
     private readonly List<string> _supportedFFmpegFormats = new()
     {
         FFmpegFormat.NV12,
         FFmpegFormat.P010LE
     };
-
-    public QsvHardwareAccelerationOption(Option<string> qsvDevice) => _qsvDevice = qsvDevice;
 
     public override string[] GlobalOptions
     {
@@ -29,9 +26,14 @@ public class QsvHardwareAccelerationOption : GlobalOption
                 "-hwaccel_output_format", "qsv"
             };
 
+            if (decodeCapability is not FFmpegCapability.Hardware)
+            {
+                result.Clear();
+            }
+
             if (OperatingSystem.IsLinux())
             {
-                foreach (string qsvDevice in _qsvDevice)
+                foreach (string qsvDevice in device)
                 {
                     if (!string.IsNullOrWhiteSpace(qsvDevice))
                     {


### PR DESCRIPTION
Fixes https://github.com/ErsatzTV/ErsatzTV/issues/2071 by using software decoding when also seeking. Subsequent content on the same stream (that has no need to seek) will then use hardware-accelerated decoding.