### PR TITLE
enable write-ahead logging on all sqlite databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Expand special zero-count case for `Multiple` playout mode with playlists
   - This configuration will automatically maintain the multiple count so that it is equal to the number of items in each playlist item
   - This configuration should be used if you want to play every media item in a playlist item exactly once before advancing
+- Enable write-ahead logging (WAL) mode on SQLite databases
 
 ### Fixed
 - Fix QSV acceleration in docker with older Intel devices

--- a/ErsatzTV.Infrastructure/Data/DbInitializer.cs
+++ b/ErsatzTV.Infrastructure/Data/DbInitializer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Reflection;
+using Dapper;
 using ErsatzTV.Core.Domain;
 
 namespace ErsatzTV.Infrastructure.Data;
@@ -8,6 +9,8 @@ public static class DbInitializer
 {
     public static async Task<Unit> Initialize(TvContext context, CancellationToken cancellationToken)
     {
+        await context.Connection.ExecuteAsync("PRAGMA journal_mode=WAL", cancellationToken);
+
         if (!context.LanguageCodes.Any())
         {
             var assembly = Assembly.GetEntryAssembly();


### PR DESCRIPTION
https://learn.microsoft.com/en-us/ef/core/what-is-new/ef-core-7.0/breaking-changes?tabs=v7#higher-chance-of-busylocked-errors-on-sqlite-when-not-using-write-ahead-logging