### PR TITLE
Update audio codec in default FFmpeg profile name

### DIFF
--- a/ErsatzTV.Infrastructure/Data/DbInitializer.cs
+++ b/ErsatzTV.Infrastructure/Data/DbInitializer.cs
@@ -110,7 +110,7 @@ public static class DbInitializer
         await context.ConfigElements.AddAsync(resolutionConfig, cancellationToken);
         await context.SaveChangesAsync(cancellationToken);
 
-        var defaultProfile = FFmpegProfile.New("1920x1080 x264 ac3", resolutions[2]);
+        var defaultProfile = FFmpegProfile.New("1920x1080 x264 aac", resolutions[2]);
         await context.FFmpegProfiles.AddAsync(defaultProfile, cancellationToken);
         await context.SaveChangesAsync(cancellationToken);
 


### PR DESCRIPTION
Quick fix for mismatch against profile audio codec setting seen here

https://github.com/ErsatzTV/ErsatzTV/blob/e6824cf25147b282eb1137fc137250d3cae53f7a/ErsatzTV.Core/Domain/FFmpegProfile.cs#L46

Resolves #2607