### PR TITLE
fix: pin nvencsharp lib to 2.0.0 for linux compatibility

### DIFF
--- a/ErsatzTV.FFmpeg/ErsatzTV.FFmpeg.csproj
+++ b/ErsatzTV.FFmpeg/ErsatzTV.FFmpeg.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="CliWrap" Version="3.10.1" />
         <PackageReference Include="Hardware.Info" Version="101.1.1.1" />
         <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
-        <PackageReference Include="Lennox.NvEncSharp" Version="2.1.0" />
+        <PackageReference Include="Lennox.NvEncSharp" Version="[2.0.0]" />
         <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.7" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     </ItemGroup>


### PR DESCRIPTION
See https://github.com/jlennox/NvEncSharp/issues/19