### PR TITLE
feat: specify mode of deinterlacing for Vaapi

### DIFF
--- a/ErsatzTV.FFmpeg/Filter/Vaapi/DeinterlaceVaapiFilter.cs
+++ b/ErsatzTV.FFmpeg/Filter/Vaapi/DeinterlaceVaapiFilter.cs
@@ -6,10 +6,23 @@ public class DeinterlaceVaapiFilter : BaseFilter
 
     public DeinterlaceVaapiFilter(FrameState currentState) => _currentState = currentState;
 
+    private static string GetDeinterlaceFilter()
+    {
+        string? modeEnv = System.Environment.GetEnvironmentVariable("VAAPI_DEINT_MODE");
+        
+        if (!string.IsNullOrEmpty(modeEnv) && int.TryParse(modeEnv, out int mode))
+        {
+            return $"deinterlace_vaapi=mode={mode}";
+        }
+        
+        // No mode specified - let driver pick default
+        return "deinterlace_vaapi";
+    }
+
     public override string Filter =>
         _currentState.FrameDataLocation == FrameDataLocation.Hardware
-            ? "deinterlace_vaapi"
-            : "format=nv12|p010le|vaapi,hwupload,deinterlace_vaapi";
+            ? GetDeinterlaceFilter()
+            : $"format=nv12|p010le|vaapi,hwupload,{GetDeinterlaceFilter()}";
 
     public override FrameState NextState(FrameState currentState) => currentState with
     {


### PR DESCRIPTION
deinterlace_vaapi will default to "best available" which may be wrong for telecine. If env var VAAPI_DEINT_MODE if set, then explicitly set the interlace mode.  This is used for telecine videos (early DVD).Submitted in case you want to carry forward as submitted or in a different way. I created it this way rather than adding to the razor page to avoid dealing with the fluent migration. Take it or leave it, but I do have to use it on my setup :-) 